### PR TITLE
Report colors (#29)

### DIFF
--- a/resources/js/components/reports/ReportColors.js
+++ b/resources/js/components/reports/ReportColors.js
@@ -1,0 +1,16 @@
+/**
+* Colors for all reports
+*/
+const ReportColors = [
+    '#FFB067', // Orange
+    '#104210', // Forest green
+    '#FF7077', // Coral
+    '#ACEEF3', // Cyan
+    '#FF4500', // Red orange
+    '#FF8300', // Darker orange
+    '#DF362D', // Medium red
+    '#B7AC44', // Olive green
+    '#7A871E', // Darker olive green
+];
+
+export default ReportColors; 

--- a/resources/js/components/reports/ReportColors.js
+++ b/resources/js/components/reports/ReportColors.js
@@ -3,7 +3,6 @@
 */
 const ReportColors = [
     '#FFB067', // Orange
-    '#104210', // Forest green
     '#FF7077', // Coral
     '#ACEEF3', // Cyan
     '#FF4500', // Red orange

--- a/resources/js/components/reports/SpendingByCategory.vue
+++ b/resources/js/components/reports/SpendingByCategory.vue
@@ -5,6 +5,7 @@
 <script>
 import Chart from 'chart.js'
 import dayjs from 'dayjs'
+import colors from './ReportColors.js'
 
 export default {
     props: {
@@ -16,17 +17,7 @@ export default {
             chart: null,
             datasets: [],
             labels: [],
-            colors: [
-                '#4D4D4D',
-                '#5DA5DA',
-                '#FAA43A',
-                '#60BD68',
-                '#F17CB0',
-                '#B2912F',
-                '#B276B2',
-                '#DECF3F',
-                '#F15854',
-            ],
+            colors: colors
         }
     },
 

--- a/resources/js/components/reports/SpendingOverTime.vue
+++ b/resources/js/components/reports/SpendingOverTime.vue
@@ -5,6 +5,7 @@
 <script>
 import Chart from 'chart.js'
 import dayjs from 'dayjs'
+import colors from './ReportColors.js'
 
 export default {
     props: {
@@ -16,17 +17,7 @@ export default {
             chart: null,
             datasets: [],
             labels: [],
-            colors: [
-                '#4D4D4D',
-                '#5DA5DA',
-                '#FAA43A',
-                '#60BD68',
-                '#F17CB0',
-                '#B2912F',
-                '#B276B2',
-                '#DECF3F',
-                '#F15854',
-            ],
+            colors: colors
         }
     },
 


### PR DESCRIPTION
Addresses Issue #29 

I tried my hand at changing the report colors to use a mix of light-ish and non-saturated reds, greens, blues. Screenshots are attached. However, I think the real benefit of this PR is moving the report colors array into a separate constant that both reports can reference. That way, if you want to modify the report colors, you only have to do so in one spot. 🙂 

![image](https://user-images.githubusercontent.com/8144993/95024433-9a3c7f00-0648-11eb-9b96-a9c18239b424.png)
![image](https://user-images.githubusercontent.com/8144993/95024438-a45e7d80-0648-11eb-88f9-d5d102a83f7f.png)
![image](https://user-images.githubusercontent.com/8144993/95024440-aa545e80-0648-11eb-8a91-29a8aac4142d.png)

