### PR TITLE
fixed category view

### DIFF
--- a/resources/views/category/index.blade.php
+++ b/resources/views/category/index.blade.php
@@ -29,9 +29,9 @@
 
 				<div class="py-2">
 					<progress-bar
-						:achieved="{{ $category->spent < $category->budgeted ? 'true' : 'false' }}"
+						:achieved="{{ $category->spent <= $category->budgeted ? 'true' : 'false' }}"
 						:balance="{{ $category->spent }}"
-						:progress="{{ min($category->progress, 100) }}"
+						:progress="{{ $category->progress }}"
 					></progress-bar>
 				</div>
 


### PR DESCRIPTION
Categories can be over 100% value, this information (more than 100% - it is 105% or 175%) might be useful
+ fixed case with 100% reach (before orange progress bar started from 100% including)

Before:
![image](https://user-images.githubusercontent.com/1555767/95024505-12786400-068c-11eb-8862-124ce64544d1.png)
![image](https://user-images.githubusercontent.com/1555767/95024519-27ed8e00-068c-11eb-8377-31c5f3178438.png)

After:
![image](https://user-images.githubusercontent.com/1555767/95024530-39cf3100-068c-11eb-8f61-b1c02b99d397.png)
![image](https://user-images.githubusercontent.com/1555767/95024528-3340b980-068c-11eb-96c6-e72a7d7a5b87.png)


