### PR TITLE
Close datepicker when out of focus

### DIFF
--- a/resources/js/components/interface/InputDatepicker.vue
+++ b/resources/js/components/interface/InputDatepicker.vue
@@ -6,21 +6,21 @@
         :mode="mode"
         :popover="{ placement: 'bottom', visibility: 'click' }"
         dusk="datepicker"
-    >   
-        <template v-slot="{ inputProps, inputEvents, hidePopover }" >
+    >
+        <template v-slot="{ inputProps, inputEvents, hidePopover }">
             <div class="input-addon--end" >
-                <input type="hidden" :name="name" :value="timestamp" >
+                <input type="hidden" :name="name" :value="timestamp">
                 <input
                     type="text"
                     class="input-text pr-10"
                     :required="required"
                     v-bind="inputProps"
                     v-on="inputEvents"
-                    @blur="hidePopover" 
+                    @blur="hidePopover"
                 >
-                <span class="input-addon cursor-pointer" >
+                <span class="input-addon cursor-pointer">
                     <!-- Hidden input to apply the blur event and hide calendar -->
-                    <input type="radio" class="cursor-pointer input-addon--blur" @blur="hidePopover">
+                    <input type="radio" tabindex="-1" class="absolute w-full h-full cursor-pointer inset-0 opacity-0" @blur="hidePopover">
                     <font-awesome-icon :icon="['far', 'calendar']"/>
                 </span>
             </div>
@@ -31,10 +31,8 @@
 <script>
 import DatePicker from 'v-calendar/lib/components/date-picker.umd'
 import dayjs from 'dayjs'
-import { mixin as clickaway } from 'vue-clickaway'
 
 export default {
-    mixins: [ clickaway ],
     components: { 'v-date-picker': DatePicker },
 
     props: {
@@ -50,11 +48,6 @@ export default {
     data() {
         return {
             mutableValue: this.value || null
-        }
-    },
-    methods: {
-        test() {
-            console.log("coucou")
         }
     },
     computed: {

--- a/resources/js/components/interface/InputDatepicker.vue
+++ b/resources/js/components/interface/InputDatepicker.vue
@@ -6,18 +6,21 @@
         :mode="mode"
         :popover="{ placement: 'bottom', visibility: 'click' }"
         dusk="datepicker"
-    >
-        <template v-slot="{ inputProps, inputEvents }">
-            <div class="input-addon--end">
-                <input type="hidden" :name="name" :value="timestamp">
+    >   
+        <template v-slot="{ inputProps, inputEvents, hidePopover }" >
+            <div class="input-addon--end" >
+                <input type="hidden" :name="name" :value="timestamp" >
                 <input
                     type="text"
                     class="input-text pr-10"
                     :required="required"
                     v-bind="inputProps"
                     v-on="inputEvents"
+                    @blur="hidePopover" 
                 >
-                <span class="input-addon cursor-pointer">
+                <span class="input-addon cursor-pointer" >
+                    <!-- Hidden input to apply the blur event and hide calendar -->
+                    <input type="radio" class="cursor-pointer input-addon--blur" @blur="hidePopover">
                     <font-awesome-icon :icon="['far', 'calendar']"/>
                 </span>
             </div>
@@ -28,8 +31,10 @@
 <script>
 import DatePicker from 'v-calendar/lib/components/date-picker.umd'
 import dayjs from 'dayjs'
+import { mixin as clickaway } from 'vue-clickaway'
 
 export default {
+    mixins: [ clickaway ],
     components: { 'v-date-picker': DatePicker },
 
     props: {
@@ -47,7 +52,11 @@ export default {
             mutableValue: this.value || null
         }
     },
-
+    methods: {
+        test() {
+            console.log("coucou")
+        }
+    },
     computed: {
         date: {
             get() {

--- a/resources/js/components/interface/InputDatepicker.vue
+++ b/resources/js/components/interface/InputDatepicker.vue
@@ -6,21 +6,18 @@
         :mode="mode"
         :popover="{ placement: 'bottom', visibility: 'click' }"
         dusk="datepicker"
-    >   
-        <template v-slot="{ inputProps, inputEvents, hidePopover }" >
-            <div class="input-addon--end" >
-                <input type="hidden" :name="name" :value="timestamp" >
+    >
+        <template v-slot="{ inputProps, inputEvents }">
+            <div class="input-addon--end">
+                <input type="hidden" :name="name" :value="timestamp">
                 <input
                     type="text"
                     class="input-text pr-10"
                     :required="required"
                     v-bind="inputProps"
                     v-on="inputEvents"
-                    @blur="hidePopover" 
                 >
-                <span class="input-addon cursor-pointer" >
-                    <!-- Hidden input to apply the blur event and hide calendar -->
-                    <input type="radio" class="cursor-pointer input-addon--blur" @blur="hidePopover">
+                <span class="input-addon cursor-pointer">
                     <font-awesome-icon :icon="['far', 'calendar']"/>
                 </span>
             </div>
@@ -31,10 +28,8 @@
 <script>
 import DatePicker from 'v-calendar/lib/components/date-picker.umd'
 import dayjs from 'dayjs'
-import { mixin as clickaway } from 'vue-clickaway'
 
 export default {
-    mixins: [ clickaway ],
     components: { 'v-date-picker': DatePicker },
 
     props: {
@@ -52,11 +47,7 @@ export default {
             mutableValue: this.value || null
         }
     },
-    methods: {
-        test() {
-            console.log("coucou")
-        }
-    },
+
     computed: {
         date: {
             get() {

--- a/resources/sass/components/_input.scss
+++ b/resources/sass/components/_input.scss
@@ -71,12 +71,3 @@
         @apply pr-6;
     }
 }
-
-.input-addon--blur {
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    right: 0;
-    top: 0;
-    opacity: 0;
-}

--- a/resources/sass/components/_input.scss
+++ b/resources/sass/components/_input.scss
@@ -71,3 +71,12 @@
         @apply pr-6;
     }
 }
+
+.input-addon--blur {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    right: 0;
+    top: 0;
+    opacity: 0;
+}


### PR DESCRIPTION
Use the @blur eventListener to close the datepicker when the user clicks away or tabs away and the input loses focus. 
( I reverted the first commit because I pushed it to master instead of my branch )